### PR TITLE
Reader bugfix

### DIFF
--- a/software/v1-enlight/config.ini
+++ b/software/v1-enlight/config.ini
@@ -1,0 +1,23 @@
+[uic]
+UicProtocol=0
+UsbMode=1
+ReadcardTimeout = 60000 ; in ms, 0 means endless
+BeepVolume = 3        ; [0 ; 255] where 0 - no sound, 255 - max
+[usb]
+VendorId=25426
+ProductId=26651
+
+[com]
+ComPortPath=/dev/ttyACM
+BaudRate=115200
+
+[logger]
+ConsoleLog = ON      ; ON / OFF
+FileLog = ON         ; ON / OFF
+FileLogSize = 10000 ; size in bytes
+
+[host]
+ip = 185.162.94.67
+port = 18324 
+timeout = 15000     ; in ms
+

--- a/software/v1-enlight/dia_cardreader.cpp
+++ b/software/v1-enlight/dia_cardreader.cpp
@@ -13,15 +13,15 @@
 // If success - uses callback to report money
 // If fail - sets requested money to 0 and stoppes
 void * DiaCardReader_ExecuteDriverProgramThread(void * driverPtr) {
-    printf("Card reader execute program thread...\n");
+    fprintf(stderr, "Card reader execute program thread...\n");
 
     DiaCardReader * driver = (DiaCardReader *)driverPtr;
 
-    printf("Transaction requested for %d RUB...\n", driver->RequestedMoney);
+    fprintf(stderr, "Transaction requested for %d RUB...\n", driver->RequestedMoney);
     std::string commandLine = "./uic_payment_app o1 a" + std::to_string(driver->RequestedMoney) + " c643";
     int statusCode = system(commandLine.c_str());
 
-    printf("Card reader returned status code: %d\n", statusCode);
+    fprintf(stderr, "Card reader returned status code: %d\n", statusCode);
     if (statusCode == 0) {
         if(driver->IncomingMoneyHandler != NULL) {
             driver->IncomingMoneyHandler(driver->_Manager, DIA_ELECTRON, driver->RequestedMoney);
@@ -31,10 +31,8 @@ void * DiaCardReader_ExecuteDriverProgramThread(void * driverPtr) {
         }
     }         
 
-    pthread_mutex_lock(&driver->MoneyLock);
     driver->RequestedMoney = 0;
-    pthread_mutex_unlock(&driver->MoneyLock);
-        
+
     pthread_exit(NULL);
     return NULL;
 }
@@ -51,7 +49,7 @@ int DiaCardReader_PerformTransaction(void * specificDriver, int money) {
     }
 
     printf("DiaCardReader started Perform Transaction, money = %d\n", money);
-    pthread_mutex_lock(&driver->MoneyLock);
+
     driver->RequestedMoney = money;
     printf("Money inside driver: %d\n", driver->RequestedMoney);
 
@@ -60,7 +58,6 @@ int DiaCardReader_PerformTransaction(void * specificDriver, int money) {
         printf("\ncan't create thread :[%s]", strerror(err));
         return 1;
     }
-    pthread_mutex_unlock(&driver->MoneyLock);
     
     return DIA_CARDREADER_NO_ERROR;
 }

--- a/software/v1-enlight/dia_cardreader.cpp
+++ b/software/v1-enlight/dia_cardreader.cpp
@@ -29,9 +29,11 @@ void * DiaCardReader_ExecuteDriverProgramThread(void * driverPtr) {
         } else {
             printf("No handler to report: %d\n", driver->RequestedMoney);
         }
-    }         
+    }
 
+    pthread_mutex_lock(&driver->MoneyLock);
     driver->RequestedMoney = 0;
+    pthread_mutex_unlock(&driver->MoneyLock);
 
     pthread_exit(NULL);
     return NULL;

--- a/software/v1-enlight/dia_cardreader.cpp
+++ b/software/v1-enlight/dia_cardreader.cpp
@@ -18,12 +18,13 @@ void * DiaCardReader_ExecuteDriverProgramThread(void * driverPtr) {
     DiaCardReader * driver = (DiaCardReader *)driverPtr;
 
     fprintf(stderr, "Transaction requested for %d RUB...\n", driver->RequestedMoney);
-    
-    std::string commandLine = "./uic_payment_app o1 a" + std::to_string(driver->RequestedMoney) + " c643";
+    int money_command = driver->RequestedMoney * 100;
+
+    std::string commandLine = "./uic_payment_app o1 a" + std::to_string(money_command) + " c643";
     int statusCode = system(commandLine.c_str());
 
     fprintf(stderr, "Card reader returned status code: %d\n", statusCode);
-    if (statusCode == 0) {
+    if (statusCode == 0 || statusCode == 23040) {
         if(driver->IncomingMoneyHandler != NULL) {
             driver->IncomingMoneyHandler(driver->_Manager, DIA_ELECTRON, driver->RequestedMoney);
             printf("Reported money: %d\n", driver->RequestedMoney);

--- a/software/v1-enlight/dia_cardreader.cpp
+++ b/software/v1-enlight/dia_cardreader.cpp
@@ -18,7 +18,7 @@ void * DiaCardReader_ExecuteDriverProgramThread(void * driverPtr) {
     DiaCardReader * driver = (DiaCardReader *)driverPtr;
 
     printf("Transaction requested for %d RUB...\n", driver->RequestedMoney);
-    std::string commandLine = "./uic_payment_app o1 a0 c" + std::to_string(driver->RequestedMoney);
+    std::string commandLine = "./uic_payment_app o1 a" + std::to_string(driver->RequestedMoney) + " c643";
     int statusCode = system(commandLine.c_str());
 
     printf("Card reader returned status code: %d\n", statusCode);

--- a/software/v1-enlight/dia_cardreader.cpp
+++ b/software/v1-enlight/dia_cardreader.cpp
@@ -21,7 +21,6 @@ void * DiaCardReader_ExecuteDriverProgramThread(void * driverPtr) {
     
     std::string commandLine = "./uic_payment_app o1 a" + std::to_string(driver->RequestedMoney) + " c643";
     int statusCode = system(commandLine.c_str());
-    //printf("Command line: %s\n", commandLine.c_str());
 
     fprintf(stderr, "Card reader returned status code: %d\n", statusCode);
     if (statusCode == 0) {
@@ -56,8 +55,7 @@ int DiaCardReader_PerformTransaction(void * specificDriver, int money) {
 
     driver->RequestedMoney = money;
     printf("Money inside driver: %d\n", driver->RequestedMoney);
-    //int status_code = system("./test.exe");
-    //printf("CODE: %d\n", status_code);
+    
     int err = pthread_create(&driver->ExecuteDriverProgramThread, NULL, DiaCardReader_ExecuteDriverProgramThread, driver);
     if (err != 0) {
         printf("\ncan't create thread :[%s]", strerror(err));

--- a/software/v1-enlight/dia_configuration/dia_configuration.cpp
+++ b/software/v1-enlight/dia_configuration/dia_configuration.cpp
@@ -106,6 +106,7 @@ DiaConfiguration::DiaConfiguration(std::string folder) {
     _Income.totalIncomeBanknotes = 0;
     _Income.totalIncomeElectron = 0;
     _Income.totalIncomeService = 0;
+    _Income.carsTotal = 0;
 
     _Storage = CreateEmptyInterface();
 }

--- a/software/v1-enlight/dia_devicemanager.cpp
+++ b/software/v1-enlight/dia_devicemanager.cpp
@@ -61,7 +61,7 @@ int DiaDeviceManager_CheckNV9(char* PortName) {
 
     // Check existance of port in list
     if (devicePortPosition != std::string::npos) {
-        size_t deviceNamePosition = bashOutput.find("E0A2E1");
+        size_t deviceNamePosition = bashOutput.find("NV9USB");
 
         // Compare distance between positions with maxDiff const
         if (deviceNamePosition != std::string::npos && 

--- a/software/v1-enlight/dia_devicemanager.cpp
+++ b/software/v1-enlight/dia_devicemanager.cpp
@@ -58,14 +58,20 @@ int DiaDeviceManager_CheckNV9(char* PortName) {
     // Get short name of port, for instance:
     //   /dev/ttyACM0 ==> /ttyACM0
     std::string shortPortName = portName.substr(4, 7);
+    printf("Port short name: %s\n", shortPortName.c_str());
 
     size_t devicePortPosition = bashOutput.find(shortPortName);
+    printf("Device Port Position: %d\n", (int)devicePortPosition);
 
     // Check existance of port in list
     if (devicePortPosition != std::string::npos) {
+        printf("Port exists!\n");
 
         size_t deviceNamePosition = bashOutput.find("E0A2E1");
-        
+        printf("Device Name Position: %d\n", (int)deviceNamePosition);
+        size_t tmp = devicePortPosition - deviceNamePosition; 
+        printf("Difference between Name and Port: %d\n", (int)tmp);
+
         if (deviceNamePosition != std::string::npos && 
             devicePortPosition - deviceNamePosition < maxDiff) {
                 printf("\nFound NV9 on port %s\n\n", PortName);

--- a/software/v1-enlight/dia_devicemanager.cpp
+++ b/software/v1-enlight/dia_devicemanager.cpp
@@ -57,7 +57,7 @@ int DiaDeviceManager_CheckNV9(char* PortName) {
 
     // Get short name of port, for instance:
     //   /dev/ttyACM0 ==> /ttyACM0
-    std::string shortPortName = portName.substr(4, 7);
+    std::string shortPortName = portName.substr(4, 8);
     printf("Port short name: %s\n", shortPortName.c_str());
 
     size_t devicePortPosition = bashOutput.find(shortPortName);

--- a/software/v1-enlight/dia_devicemanager.cpp
+++ b/software/v1-enlight/dia_devicemanager.cpp
@@ -248,7 +248,7 @@ void DiaDeviceManager_AbortTransaction(void *manager) {
         printf("DiaDeviceManager Abort Transaction got NULL driver\n");
         return;
     }
-    DiaCardReader_AbortTransaction(&Manager->_CardReader);
+    DiaCardReader_AbortTransaction(Manager->_CardReader);
 }
 
 int DiaDeviceManager_GetTransactionStatus(void *manager) {
@@ -258,5 +258,5 @@ int DiaDeviceManager_GetTransactionStatus(void *manager) {
         printf("DiaDeviceManager Get Transaction Status got NULL driver\n");
         return -1;
     }
-    return DiaCardReader_GetTransactionStatus(&Manager->_CardReader);
+    return DiaCardReader_GetTransactionStatus(Manager->_CardReader);
 }

--- a/software/v1-enlight/dia_devicemanager.cpp
+++ b/software/v1-enlight/dia_devicemanager.cpp
@@ -100,7 +100,8 @@ void DiaDeviceManager_CheckOrAddDevice(DiaDeviceManager *manager, char * PortNam
                 manager->_Devices.push_back(dev);
                 manager->isBanknoteReaderFound = 1;
             }
-        } else {
+        }
+        if (!isACM) { 
             printf("\nChecking port %s for MicroCoinSp...\n", PortName);
             DiaDevice * dev = new DiaDevice(PortName);
 

--- a/software/v1-enlight/dia_devicemanager.cpp
+++ b/software/v1-enlight/dia_devicemanager.cpp
@@ -62,7 +62,7 @@ int DiaDeviceManager_CheckNV9(char* PortName) {
     //   /dev/ttyACM0 ==> /ttyACM0
     std::string toCut = portName.substr(0, 4);
 
-    if (toCut != "/dev") {
+    if (toCut != std::string("/dev")) {
         printf("Invlaid port name in NV9 device check: %s\n", PortName);
         return 0;
     }

--- a/software/v1-enlight/dia_devicemanager.h
+++ b/software/v1-enlight/dia_devicemanager.h
@@ -16,6 +16,7 @@ public:
     int ServiceMoney;
     
     int NeedWorking;
+    int isBanknoteReaderFound;
     char * _PortName;
     pthread_mutex_t _DevicesLock = PTHREAD_MUTEX_INITIALIZER;
 

--- a/software/v1-enlight/dia_firmware.cpp
+++ b/software/v1-enlight/dia_firmware.cpp
@@ -463,7 +463,7 @@ int main(int argc, char ** argv) {
         dia_security_write_file(CENTRALWASH_KEY, centralKey);
         printf("Public key wrote to file: %s \n", CENTRALWASH_KEY);
     }
-
+    
     network.SetPublicKey(std::string(centralKey));
     int need_to_find = 1; 
     std::string serverIP = "";
@@ -476,7 +476,7 @@ int main(int argc, char ** argv) {
 	    need_to_find = 0;
     }
     network.SetHostAddress(serverIP);
-    
+
     // Runtime and firmware initialization
     DiaDeviceManager manager;
     DiaDeviceManager_AddCardReader(&manager);

--- a/software/v1-enlight/dia_firmware.cpp
+++ b/software/v1-enlight/dia_firmware.cpp
@@ -177,6 +177,7 @@ int request_transaction(void *object, int money) {
 int get_transaction_status(void *object) {
     DiaDeviceManager * manager = (DiaDeviceManager *)object;
     int status = DiaDeviceManager_GetTransactionStatus(manager);
+    fprintf(stderr, "Transaction status: %d\n", status);
     return status;
 }
 

--- a/software/v1-enlight/dia_network.h
+++ b/software/v1-enlight/dia_network.h
@@ -275,7 +275,7 @@ public:
         int res = -1;
 
 	    printf("Looking for Central-wash server ...\n");
-        res = this->SearchCentralServer(&serverIP, "enp0s3");
+        res = this->SearchCentralServer(&serverIP, "eth0");
         
         if (res == 0) {
             printf("Server located on: %s\n", serverIP.c_str());

--- a/software/v1-enlight/dia_network.h
+++ b/software/v1-enlight/dia_network.h
@@ -275,7 +275,7 @@ public:
         int res = -1;
 
 	    printf("Looking for Central-wash server ...\n");
-        res = this->SearchCentralServer(&serverIP, "eth0");
+        res = this->SearchCentralServer(&serverIP, "enp0s3");
         
         if (res == 0) {
             printf("Server located on: %s\n", serverIP.c_str());

--- a/software/v1-enlight/dia_runtime/dia_runtime.cpp
+++ b/software/v1-enlight/dia_runtime/dia_runtime.cpp
@@ -19,7 +19,7 @@ int DiaRuntime::Init(std::string folder, json_t * src_json) {
 }
 
 void printMessage(const std::string& s) {
-    std::cout << s << std::endl;
+    fprintf(stderr, "%s\n", s.c_str());
 }
 
 int DiaRuntime::Init(std::string folder, std::string src_str) {

--- a/software/v1-enlight/samples/wash/script.lua
+++ b/software/v1-enlight/samples/wash/script.lua
@@ -4,7 +4,7 @@ setup = function()
     -- global variables
     balance = 0.0
 
-    min_electron_balance = 100
+    min_electron_balance = 50
     max_electron_balance = 900
     electron_amount_step = 25
     electron_balance = min_electron_balance
@@ -165,7 +165,7 @@ wait_for_card_mode = function()
     if is_transaction_started == false then
         waiting_loops = wait_card_mode_seconds * 10;
 
-        request_transaction(electron_balance * 100)
+        request_transaction(electron_balance)
         electron_balance = min_electron_balance
         is_transaction_started = true
     end

--- a/software/v1-enlight/samples/wash/script.lua
+++ b/software/v1-enlight/samples/wash/script.lua
@@ -196,7 +196,7 @@ wait_for_card_mode = function()
 
     smart_delay(100)
     waiting_loops = waiting_loops - 1
---    printMessage(waiting_loops)
+   
     return mode_wait_for_card
 end
 

--- a/software/v1-enlight/samples/wash/script.lua
+++ b/software/v1-enlight/samples/wash/script.lua
@@ -17,7 +17,7 @@ setup = function()
     welcome_mode_seconds = 3
     thanks_mode_seconds = 120
     free_pause_seconds = 120
-    wait_card_mode_seconds = 120
+    wait_card_mode_seconds = 40
     
     hascardreader = true
     is_transaction_started = false
@@ -162,7 +162,7 @@ wait_for_card_mode = function()
     -- check animation
     turn_light(0, animation.idle)
 
-    if is_transaction_started ~= true then
+    if is_transaction_started == false then
         waiting_loops = wait_card_mode_seconds * 10;
 
         request_transaction(electron_balance * 100)
@@ -196,7 +196,7 @@ wait_for_card_mode = function()
 
     smart_delay(100)
     waiting_loops = waiting_loops - 1
-    
+--    printMessage(waiting_loops)
     return mode_wait_for_card
 end
 
@@ -326,7 +326,7 @@ thanks_mode = function()
     send_receipt(post_position, 0, kasse_balance)
     kasse_balance = 0
 
-    return mode_ask_for_money
+    return mode_choose_method
 end
 
 

--- a/software/v1-enlight/samples/wash/script.lua
+++ b/software/v1-enlight/samples/wash/script.lua
@@ -170,6 +170,11 @@ wait_for_card_mode = function()
         is_transaction_started = true
     end
 
+    pressed_key = get_key()
+    if pressed_key > 0 and pressed_key < 7 then
+        waiting_loops = 0
+    end
+
     update_balance()
     if balance > 0.99 then
         status = get_transaction_status()

--- a/software/v1-enlight/samples/wash/script.lua
+++ b/software/v1-enlight/samples/wash/script.lua
@@ -179,7 +179,6 @@ wait_for_card_mode = function()
     if balance > 0.99 then
         status = get_transaction_status()
         if status ~= 0 then 
-            -- need to test this
             abort_transaction()
         end
         is_transaction_started = false
@@ -188,7 +187,10 @@ wait_for_card_mode = function()
 
     if waiting_loops <= 0 then
         is_transaction_started = false
-        abort_transaction()
+	status = get_transaction_status()
+	if status ~= 0 then
+	    abort_transaction()
+	end
         return mode_choose_method
     end
 

--- a/software/v1-enlight/samples/wash/script.lua
+++ b/software/v1-enlight/samples/wash/script.lua
@@ -19,7 +19,7 @@ setup = function()
     free_pause_seconds = 120
     wait_card_mode_seconds = 120
     
-    hascardreader = false
+    hascardreader = true
     is_transaction_started = false
 
     price_p1 = 0
@@ -166,7 +166,7 @@ wait_for_card_mode = function()
         waiting_loops = wait_card_mode_seconds * 10;
 
         request_transaction(electron_balance * 100)
-        electron_balance = 0
+        electron_balance = min_electron_balance
         is_transaction_started = true
     end
 


### PR DESCRIPTION
Several bugs fixed, related to NFC card and banknote readers:
1) NFC card waiting loop in Lua script (./samples/wash/script.lua) fixed to be unblocking. Now we can abort it at any moment. 
2) DiaDeviceManager (dia_devicemanager.cpp) now searches for NV9 banknote reader correctly. It will check every ACM serial port, looking for special NV9 ID. Maximum amount of banknote readers is limited to 1. 
3) Command line string to call bank card reader .exe is fixed (dia_cardreader.cpp), currency code is 643 (RUB) now.

Please, don't merge this branch, until the code isn't tested properly.